### PR TITLE
Add scroll progress indicator for disassembly tour

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -41,3 +41,23 @@ main {
   padding: 20px;
   text-align: center;
 }
+
+#site-header {
+  margin-top: 4px;
+}
+
+#progress-bar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 4px;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 3;
+}
+
+#progress-fill {
+  width: 0%;
+  height: 100%;
+  background: #00ff41;
+}

--- a/index.html
+++ b/index.html
@@ -8,6 +8,10 @@
   <link rel="stylesheet" href="/css/style.css" />
 </head>
 <body>
+  <div id="progress-bar" aria-hidden="true">
+    <div id="progress-fill"></div>
+  </div>
+
   <!-- Site Header -->
   <header id="site-header">
     <h1>Abhay Bhingradia</h1>

--- a/js/main.js
+++ b/js/main.js
@@ -62,6 +62,7 @@ function buildDisassemblyTimeline(parts) {
 
   // Hook scroll to timeline
   window.addEventListener('scroll', syncTimelineWithScroll);
+  syncTimelineWithScroll();
 }
 
 // Sync Timeline Seek to Scroll Position
@@ -71,6 +72,11 @@ function syncTimelineWithScroll() {
   const maxScroll = document.body.scrollHeight - window.innerHeight;
   const progress = Math.min(Math.max(scrollY / maxScroll, 0), 1);
   disassemblyTimeline.seek(disassemblyTimeline.duration * progress);
+
+  const progressFill = document.getElementById('progress-fill');
+  if (progressFill) {
+    progressFill.style.width = `${progress * 100}%`;
+  }
 }
 
 // Render Loop


### PR DESCRIPTION
## Summary
- show scroll progress with a fixed bar at the top of the page
- style progress indicator to match existing retro theme
- keep progress bar synced with scroll-triggered 3D animation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c1778ffe30832bb2590d95cb420dd2