### PR TITLE
feat: add terminal overlay

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -41,3 +41,70 @@ main {
   padding: 20px;
   text-align: center;
 }
+
+/* Terminal overlay styling */
+#terminal-overlay {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  max-height: 40vh;
+  background: rgba(0, 0, 0, 0.85);
+  color: #00ff41;
+  font-family: 'Courier New', monospace;
+  display: flex;
+  flex-direction: column;
+  z-index: 3;
+}
+
+#terminal-output {
+  flex: 1;
+  overflow-y: auto;
+  padding: 10px;
+}
+
+#terminal-input-line {
+  display: flex;
+  align-items: center;
+  padding: 10px;
+  position: relative;
+}
+
+#terminal-prompt {
+  margin-right: 5px;
+}
+
+.input-wrapper {
+  position: relative;
+  flex: 1;
+}
+
+#terminal-input {
+  width: 100%;
+  background: transparent;
+  border: none;
+  color: #00ff41;
+  outline: none;
+  font-family: inherit;
+  caret-color: transparent;
+}
+
+#terminal-cursor {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 1ch;
+  height: 1em;
+  background: #00ff41;
+  animation: blink 1s steps(2, start) infinite;
+}
+
+@keyframes blink {
+  to { visibility: hidden; }
+}
+
+.terminal-hint {
+  padding: 0 10px 10px;
+  font-size: 0.8rem;
+  opacity: 0.5;
+}

--- a/index.html
+++ b/index.html
@@ -46,6 +46,19 @@
     <small>© 2025 Abhay Bhingradia</small>
   </footer>
 
+  <!-- Terminal Overlay -->
+  <div id="terminal-overlay">
+    <div id="terminal-output" aria-live="polite"></div>
+    <div id="terminal-input-line">
+      <span id="terminal-prompt">visitor@portfolio:~$</span>
+      <div class="input-wrapper">
+        <input id="terminal-input" type="text" autocomplete="off" aria-label="Terminal input" />
+        <span id="terminal-cursor"></span>
+      </div>
+    </div>
+    <div class="terminal-hint">Type "help" to begin your journey</div>
+  </div>
+
   <!-- Main 3D script -->
   <script type="module" src="/js/main.js"></script>
 </body>

--- a/js/main.js
+++ b/js/main.js
@@ -2,6 +2,7 @@
 import * as THREE from 'three';
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 import anime from 'animejs/lib/anime.es.js';
+import { TerminalUI } from './modules/TerminalUI.js';
 
 // Scene Setup
 const canvas = document.getElementById('scene');
@@ -18,6 +19,11 @@ scene.add(new THREE.AmbientLight(0xffffff, 0.6));
 const directionalLight = new THREE.DirectionalLight(0xffffff, 0.8);
 directionalLight.position.set(5, 10, 7);
 scene.add(directionalLight);
+
+// Initialize terminal UI
+const terminalUI = new TerminalUI();
+terminalUI.init().catch(console.error);
+window.portfolioApp = { terminalUI };
 
 // Load 3D Model
 let disassemblyTimeline;


### PR DESCRIPTION
## Summary
- add terminal overlay markup and styles for retro command interface
- initialize TerminalUI module in main script for interactive navigation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c182469e94832bb25230c0770da656