### PR TITLE
Add animated landing page with user and computer modes

### DIFF
--- a/computer.html
+++ b/computer.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Abhay Bhingradia – Computer Friendly Page</title>
+  <meta name="description" content="Interactive 3D disassembly tour of a laptop showcasing Abhay Bhingradia's portfolio." />
+  <link rel="stylesheet" href="/css/style.css" />
+</head>
+<body>
+  <!-- Site Header -->
+  <header id="site-header">
+    <h1>Abhay Bhingradia</h1>
+    <nav>
+      <a href="#about">About</a>
+      <a href="#projects">Projects</a>
+      <a href="#contact">Contact</a>
+    </nav>
+  </header>
+
+  <!-- 3D Canvas Container -->
+  <div id="canvas-container">
+    <canvas id="scene" aria-label="3D interactive disassembly scene"></canvas>
+  </div>
+
+  <!-- Scroll‐driven Content Sections -->
+  <main>
+    <section id="about" class="scroll-step">
+      <h2>About Me</h2>
+      <p><!-- Your bio here --></p>
+    </section>
+
+    <section id="projects" class="scroll-step">
+      <h2>Key Projects</h2>
+      <p><!-- Highlight your work --></p>
+    </section>
+
+    <section id="contact" class="scroll-step">
+      <h2>Contact</h2>
+      <p><!-- Your email and social links --></p>
+    </section>
+  </main>
+
+  <!-- Site Footer -->
+  <footer>
+    <small>© 2025 Abhay Bhingradia</small>
+  </footer>
+
+  <!-- Terminal Overlay -->
+  <div id="terminal-overlay">
+    <div id="terminal-output" aria-live="polite"></div>
+    <div id="terminal-input-line">
+      <span id="terminal-prompt">visitor@portfolio:~$</span>
+      <div class="input-wrapper">
+        <input id="terminal-input" type="text" autocomplete="off" aria-label="Terminal input" />
+        <span id="terminal-cursor"></span>
+      </div>
+    </div>
+    <div class="terminal-hint">Type "help" to begin your journey</div>
+  </div>
+
+  <!-- Main 3D script -->
+  <script type="module" src="/js/main.js"></script>
+</body>
+</html>

--- a/css/landing.css
+++ b/css/landing.css
@@ -1,0 +1,33 @@
+body {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  background: linear-gradient(135deg, #1e3c72, #2a5298);
+  color: #fff;
+  font-family: 'Arial', sans-serif;
+  text-align: center;
+}
+
+.buttons {
+  display: flex;
+  gap: 20px;
+}
+
+button {
+  padding: 15px 25px;
+  font-size: 1.1rem;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  background: #ff4081;
+  color: #fff;
+  box-shadow: 0 4px 10px rgba(0,0,0,0.3);
+  transition: background 0.3s ease;
+}
+
+button:hover {
+  background: #f50057;
+}

--- a/index.html
+++ b/index.html
@@ -2,64 +2,17 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Abhay Bhingradia – 3D Disassembly Tour</title>
-  <meta name="description" content="Interactive 3D disassembly tour of a laptop showcasing Abhay Bhingradia's portfolio." />
-  <link rel="stylesheet" href="/css/style.css" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Abhay Bhingradia</title>
+  <link rel="stylesheet" href="/css/landing.css" />
 </head>
 <body>
-  <!-- Site Header -->
-  <header id="site-header">
-    <h1>Abhay Bhingradia</h1>
-    <nav>
-      <a href="#about">About</a>
-      <a href="#projects">Projects</a>
-      <a href="#contact">Contact</a>
-    </nav>
-  </header>
-
-  <!-- 3D Canvas Container -->
-  <div id="canvas-container">
-    <canvas id="scene" aria-label="3D interactive disassembly scene"></canvas>
+  <h1 id="title">Abhay Bhingradia</h1>
+  <div class="buttons">
+    <a href="/user.html"><button id="user-btn">Go to the User friendly page</button></a>
+    <a href="/computer.html"><button id="computer-btn">Go to the Computer friendly page</button></a>
   </div>
-
-  <!-- Scroll‐driven Content Sections -->
-  <main>
-    <section id="about" class="scroll-step">
-      <h2>About Me</h2>
-      <p><!-- Your bio here --></p>
-    </section>
-
-    <section id="projects" class="scroll-step">
-      <h2>Key Projects</h2>
-      <p><!-- Highlight your work --></p>
-    </section>
-
-    <section id="contact" class="scroll-step">
-      <h2>Contact</h2>
-      <p><!-- Your email and social links --></p>
-    </section>
-  </main>
-
-  <!-- Site Footer -->
-  <footer>
-    <small>© 2025 Abhay Bhingradia</small>
-  </footer>
-
-  <!-- Terminal Overlay -->
-  <div id="terminal-overlay">
-    <div id="terminal-output" aria-live="polite"></div>
-    <div id="terminal-input-line">
-      <span id="terminal-prompt">visitor@portfolio:~$</span>
-      <div class="input-wrapper">
-        <input id="terminal-input" type="text" autocomplete="off" aria-label="Terminal input" />
-        <span id="terminal-cursor"></span>
-      </div>
-    </div>
-    <div class="terminal-hint">Type "help" to begin your journey</div>
-  </div>
-
-  <!-- Main 3D script -->
-  <script type="module" src="/js/main.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/animejs/3.2.1/anime.min.js"></script>
+  <script src="/js/landing.js"></script>
 </body>
 </html>

--- a/js/landing.js
+++ b/js/landing.js
@@ -1,0 +1,14 @@
+window.addEventListener('DOMContentLoaded', () => {
+  anime.timeline({ easing: 'easeOutExpo', duration: 750 })
+    .add({
+      targets: '#title',
+      opacity: [0, 1],
+      translateY: [-50, 0]
+    })
+    .add({
+      targets: '.buttons button',
+      opacity: [0, 1],
+      translateY: [50, 0],
+      delay: anime.stagger(200)
+    }, '-=300');
+});

--- a/js/main.js
+++ b/js/main.js
@@ -21,9 +21,12 @@ directionalLight.position.set(5, 10, 7);
 scene.add(directionalLight);
 
 // Initialize terminal UI
-const terminalUI = new TerminalUI();
-terminalUI.init().catch(console.error);
-window.portfolioApp = { terminalUI };
+let terminalUI = null;
+if (document.getElementById('terminal-overlay')) {
+  terminalUI = new TerminalUI();
+  terminalUI.init().catch(console.error);
+  window.portfolioApp = { terminalUI };
+}
 
 // Load 3D Model
 let disassemblyTimeline;

--- a/user.html
+++ b/user.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Abhay Bhingradia – User Friendly Page</title>
+  <meta name="description" content="Interactive 3D disassembly tour of a laptop showcasing Abhay Bhingradia's portfolio." />
+  <link rel="stylesheet" href="/css/style.css" />
+</head>
+<body>
+  <!-- Site Header -->
+  <header id="site-header">
+    <h1>Abhay Bhingradia</h1>
+    <nav>
+      <a href="#about">About</a>
+      <a href="#projects">Projects</a>
+      <a href="#contact">Contact</a>
+    </nav>
+  </header>
+
+  <!-- 3D Canvas Container -->
+  <div id="canvas-container">
+    <canvas id="scene" aria-label="3D interactive disassembly scene"></canvas>
+  </div>
+
+  <!-- Scroll‐driven Content Sections -->
+  <main>
+    <section id="about" class="scroll-step">
+      <h2>About Me</h2>
+      <p><!-- Your bio here --></p>
+    </section>
+
+    <section id="projects" class="scroll-step">
+      <h2>Key Projects</h2>
+      <p><!-- Highlight your work --></p>
+    </section>
+
+    <section id="contact" class="scroll-step">
+      <h2>Contact</h2>
+      <p><!-- Your email and social links --></p>
+    </section>
+  </main>
+
+  <!-- Site Footer -->
+  <footer>
+    <small>© 2025 Abhay Bhingradia</small>
+  </footer>
+  <!-- Main 3D script -->
+  <script type="module" src="/js/main.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add animated landing page with options to visit user- or computer-friendly modes
- Separate existing interface into `user.html` and `computer.html`
- Make main script gracefully skip terminal UI when not needed

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: vite: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_68c191bbc814832ba84a9488ffb3634c